### PR TITLE
Acceptance region in plots

### DIFF
--- a/server.R
+++ b/server.R
@@ -180,7 +180,7 @@ shinyServer(function(input, output, session) {
                               "Greater" = c(mydist.q[3],1.1*maxx),
                               "Lesser" = c(1.1*-maxx, mydist.q[4])
                                     )
-                polygon(x=rejection, y=range(oh$counts), col=gray.colors(10, alpha=0.5)[1])
+                polygon(x=rep(rejection,2), y=rep(range(oh$counts), 2), col=gray.colors(10, alpha=0.5)[1])
             })
             ### simply displays the statistic of interest
             output$stat <- renderText({

--- a/server.R
+++ b/server.R
@@ -177,10 +177,10 @@ shinyServer(function(input, output, session) {
                 mydist.q <- quantile(distribution(), c(0.025, 0.975, 0.95, 0.05))
                 rejection <- switch(input$pside,
                               "Two sided" = mydist.q[1:2],
-                              "Greater" = mydist.q[3],
-                              "Lesser" = mydist.q[4]
+                              "Greater" = c(mydist.q[3],1.1*maxx)
+                              "Lesser" = c(1.1*-maxx, mydist.q[4])
                                     )
-                abline(v=rejection, col="red", lwd=2)
+                polygon(x=rejection, y=range(oh$counts), col=gray.colors(10, alpha=0.5)[1])
             })
             ### simply displays the statistic of interest
             output$stat <- renderText({

--- a/server.R
+++ b/server.R
@@ -177,7 +177,7 @@ shinyServer(function(input, output, session) {
                 mydist.q <- quantile(distribution(), c(0.025, 0.975, 0.95, 0.05))
                 rejection <- switch(input$pside,
                               "Two sided" = mydist.q[1:2],
-                              "Greater" = c(mydist.q[3],1.1*maxx)
+                              "Greater" = c(mydist.q[3],1.1*maxx),
                               "Lesser" = c(1.1*-maxx, mydist.q[4])
                                     )
                 polygon(x=rejection, y=range(oh$counts), col=gray.colors(10, alpha=0.5)[1])

--- a/server.R
+++ b/server.R
@@ -180,8 +180,8 @@ shinyServer(function(input, output, session) {
                               "Greater" = c(mydist.q[3],1.1*maxx),
                               "Lesser" = c(1.1*-maxx, mydist.q[4])
                                     )
-                rect(xleft=rejection[1], xright=rejection[2], ybottom=min(oh$counts), ytop=max(oh$counts),
-                     col=gray.colors(10, alpha=0.5)[1])
+                rect(xleft=rejection[1], xright=rejection[2], ybottom = 0, ytop=max(oh$counts),
+                     col=gray.colors(1,alpha=.3), lwd=0)
             })
             ### simply displays the statistic of interest
             output$stat <- renderText({

--- a/server.R
+++ b/server.R
@@ -172,7 +172,7 @@ shinyServer(function(input, output, session) {
                 hist(mydist, xlim=1.1*c(-maxx,maxx), col="orange1", border="white", 
                      add=TRUE, breaks = oh$breaks)
               # vertical line with the original statistic
-                abline(v = line, lty=2, col="blue")
+                abline(v = line, lty=2, col="red")
              # Vertical lines for rejection region
                 mydist.q <- quantile(distribution(), c(0.025, 0.975, 0.95, 0.05))
                 rejection <- switch(input$pside,
@@ -180,7 +180,8 @@ shinyServer(function(input, output, session) {
                               "Greater" = c(mydist.q[3],1.1*maxx),
                               "Lesser" = c(1.1*-maxx, mydist.q[4])
                                     )
-                polygon(x=rep(rejection,2), y=rep(range(oh$counts), 2), col=gray.colors(10, alpha=0.5)[1])
+                rect(xleft=rejection[1], xright=rejection[2], ybottom=min(oh$counts), ytop=max(oh$counts),
+                     col=gray.colors(10, alpha=0.5)[1])
             })
             ### simply displays the statistic of interest
             output$stat <- renderText({

--- a/server.R
+++ b/server.R
@@ -161,12 +161,13 @@ shinyServer(function(input, output, session) {
               line <- svalue(); if(abs(line) > maxx) maxx = abs(line); 
               # draws the histogram
               oh <- hist(mydist, xlim=1.1*c(-maxx, maxx), main = "Distribution of the statistic of interest", col="skyblue", border="white", xlab="Statistic of interest")
-              # adds the extreme values in orange. the definition of "extreme" depends on whether the test is
+              # adds the rejection region in orange. The definition of the region depends on whether the test is
               # one sided or two sided
+              mydist.q <- quantile(mydist, probs=c(0.025, 0.05, 0.95, 0.975))
               mydist <- switch(input$pside,
-                              "Two sided" = mydist[abs(mydist) >= abs(line)],
-                              "Greater" = mydist[mydist >= line],
-                              "Lesser" = mydist[mydist <= line]
+                              "Two sided" = mydist[mydist < mydist.q[1] || mydist > mydist.q[4]],
+                              "Greater" = mydist[mydist > mydist.q[3]],
+                              "Lesser" = mydist[mydist < mydist.q[2]]
                               )
               if(length(mydist)>0) 
                 hist(mydist, xlim=1.1*c(-maxx,maxx), col="orange1", border="white", 

--- a/server.R
+++ b/server.R
@@ -174,7 +174,7 @@ shinyServer(function(input, output, session) {
               # vertical line with the original statistic
                 abline(v = line, lty=2, col="blue")
              # Vertical lines for rejection region
-                mydist.q <- quantile(mydist, c(0.025, 0.975, 0.95, 0.05))
+                mydist.q <- quantile(distribution(), c(0.025, 0.975, 0.95, 0.05))
                 rejection <- switch(input$pside,
                               "Two sided" = mydist.q[1:2],
                               "Greater" = mydist.q[3],

--- a/server.R
+++ b/server.R
@@ -161,19 +161,26 @@ shinyServer(function(input, output, session) {
               line <- svalue(); if(abs(line) > maxx) maxx = abs(line); 
               # draws the histogram
               oh <- hist(mydist, xlim=1.1*c(-maxx, maxx), main = "Distribution of the statistic of interest", col="skyblue", border="white", xlab="Statistic of interest")
-              # adds the rejection region in orange. The definition of the region depends on whether the test is
+              # adds the extreme values in orange. the definition of "extreme" depends on whether the test is
               # one sided or two sided
-              mydist.q <- quantile(mydist, probs=c(0.025, 0.05, 0.95, 0.975))
               mydist <- switch(input$pside,
-                              "Two sided" = mydist[mydist < mydist.q[1] || mydist > mydist.q[4]],
-                              "Greater" = mydist[mydist > mydist.q[3]],
-                              "Lesser" = mydist[mydist < mydist.q[2]]
+                              "Two sided" = mydist[abs(mydist) >= abs(line)],
+                              "Greater" = mydist[mydist >= line],
+                              "Lesser" = mydist[mydist <= line]
                               )
               if(length(mydist)>0) 
                 hist(mydist, xlim=1.1*c(-maxx,maxx), col="orange1", border="white", 
                      add=TRUE, breaks = oh$breaks)
               # vertical line with the original statistic
-              abline(v = line, lty=2, col="red")
+                abline(v = line, lty=2, col="blue")
+             # Vertical lines for rejection region
+                mydist.q <- quantile(mydist, c(0.025, 0.975, 0.95, 0.05))
+                rejection <- switch(input$pside,
+                              "Two sided" = mydist.q[1:2],
+                              "Greater" = mydist.q[3],
+                              "Lesser" = mydist.q[4]
+                                    )
+                abline(v=rejection, col="red", lwd=2)
             })
             ### simply displays the statistic of interest
             output$stat <- renderText({

--- a/server.R
+++ b/server.R
@@ -177,8 +177,8 @@ shinyServer(function(input, output, session) {
                 mydist.q <- quantile(distribution(), c(0.025, 0.975, 0.95, 0.05))
                 rejection <- switch(input$pside,
                               "Two sided" = mydist.q[1:2],
-                              "Greater" = c(mydist.q[3],1.1*maxx),
-                              "Lesser" = c(1.1*-maxx, mydist.q[4])
+                              "Greater" = c(1.1*-maxx, mydist.q[3]),
+                              "Lesser" = c(mydist.q[4], 1.1*maxx)
                                     )
                 rect(xleft=rejection[1], xright=rejection[2], ybottom = 0, ytop=max(oh$counts),
                      col=gray.colors(1,alpha=.3), lwd=0)

--- a/ui.R
+++ b/ui.R
@@ -160,7 +160,7 @@ shinyUI(fluidPage(theme= "bootstrap.css",
                           randomization from your data. The histograms bins in orange (if any) represent those
                           simulations in which the statistic had a value that's ", em("equal 
                           to or more extreme"), " than the statistic calculated on your original data
-                          (represented by the dotted red line). This leads to a p-value of:"),
+                          (represented by the dotted red line). The gray area delimits the values of the statistics under which the null hypothesis should be accepted with 5% of chance of error. The proportion of simulations with statistics more extreme than the observed (p-value of) is:"),
                  h3(textOutput("p"))
                )
              )


### PR DESCRIPTION
Assuming that Neymann-Perason criterium is a more proper way to think and learn significance tests than the p-value, this PR adds the "acceptance" region to the plot of the distribution of the statistics of interest. In some case the limit of one tailed regions are not reaching the end of x-axis (see azteca for example). But the general idea is here. Very important to our field course, as we would try to avoid the incorrect idea that p-values indicates the strenght of support.
