### PR TITLE
Separated conditional panel for F

### DIFF
--- a/ui.R
+++ b/ui.R
@@ -71,7 +71,7 @@ shinyUI(fluidPage(theme= "bootstrap.css",
                          choices=c("Column mean" = "smean",
                                    "Column standard deviation" = "ssd",
                              "Mean difference between 2 groups" = "meandif",
-                             "F-statistic for more than 2 groups" = "Fstatistic",
+                             "Variance ratio (F) for more than 2 groups" = "Fstatistic",
                                    "Mean difference between columns" = "meandifc",
                                    "Mean sum of rows" = "srow",
                                    "Mean sum of columns" = "scol",
@@ -137,12 +137,12 @@ shinyUI(fluidPage(theme= "bootstrap.css",
                  ),
              ### Panel for F-statistic:
              conditionalPanel(
-               helpText("The F-statistic function splits the data acording to a categorical variable. Then it calculates
-                           the ratio of among-group to within-group variances (F-statistic).
-                           Large differences between means of at least two groups lead to large values of F."),
-               selectInput("s1", "Categorical variable column: ", 1),
-               selectInput("s2", "Numerical variable column: ", 2),
-               condition="input.stat=='Fstatistic'"
+                 helpText("The variance ratio function splits the data acording to a categorical variable.
+                            Then it calculates the ratio of among-group to within-group variances, also known as Fisher's F.
+                            Large differences between means of at least two groups lead to large values of F."),
+                 selectInput("s1", "Categorical variable column: ", 1),
+                 selectInput("s2", "Numerical variable column: ", 2),
+                 condition="input.stat == 'Fstatistic'"
                  ),
              ### Panel for meandifc:
              conditionalPanel(

--- a/ui.R
+++ b/ui.R
@@ -60,6 +60,7 @@ shinyUI(fluidPage(theme= "bootstrap.css",
                               '"'))
                  ),
                helpText("Make sure that the data is correctly interpreted in the display below!", style="color:#f30;"),
+               helpText("First rows of your data:"),
                condition="input.datasource	== 'upload file'"
              ))),
              tableOutput("view"),

--- a/ui.R
+++ b/ui.R
@@ -131,12 +131,18 @@ shinyUI(fluidPage(theme= "bootstrap.css",
                helpText("The mean difference function splits the data acording to a categorical variable. Then it calculates 
                         the mean for each group, and subtracts one from another. Note that this is designed 
                         to work with only ",em("TWO")," categories!"),
-                 helpText("The F-statistic function splits the data acording to a categorical variable. Then it calculates
-                           the ratio of among-group to within-group variances (F-statistic).
-                           A large difference between means of at least two groups lead to large values of F."),
                selectInput("s1", "Categorical variable column: ", 1),
                selectInput("s2", "Numerical variable column: ", 2),
-               condition="input.stat == 'meandif' || input.stat=='Fstatistic'"
+               condition="input.stat == 'meandif'"
+                 ),
+             ### Panel for F-statistic:
+             conditionalPanel(
+               helpText("The F-statistic function splits the data acording to a categorical variable. Then it calculates
+                           the ratio of among-group to within-group variances (F-statistic).
+                           Large differences between means of at least two groups lead to large values of F."),
+               selectInput("s1", "Categorical variable column: ", 1),
+               selectInput("s2", "Numerical variable column: ", 2),
+               condition="input.stat=='Fstatistic'"
                  ),
              ### Panel for meandifc:
              conditionalPanel(


### PR DESCRIPTION
To display the correct help text for variance ratio (F) and difference between two factors. Nevertheless a new issue poped out: for F the columns numbers for selection are shown, not the names. Weird, as I only copied the conditionalPanel statement from one to another.
