### PR TITLE
Allow user to fix the statistics

### DIFF
--- a/server.R
+++ b/server.R
@@ -94,7 +94,8 @@ shinyServer(function(input, output, session) {
                 eval(parse(text=input$stat))
             })
             ### the statistic applied to the original data
-            svalue <- reactive({
+    svalue <- reactive({
+        if(!is.na(as.numeric(input$fixeds))) return(as.numeric(input$fixeds)); ## fix statistics if a value is provided to fixeds
               f <- statistic()
               f(data())
             })
@@ -232,6 +233,13 @@ shinyServer(function(input, output, session) {
               s <- paste(round(svalue(), 3), collapse = " ")
               paste(tr("Statistic of interest"),": ", s, "\n", sep="")
             })
+    ## Conditional messages for statisc calculated from data or fixed by the user
+    output$stats.help <- renderText({
+        if(!is.na(as.numeric(input$fixeds)))
+            return(tr("Function above does not apply because the statistics was fixed by the user (see Resampling tab)."));
+        return(tr("Below you see the result of this function applied to the original data:"))
+    }
+    )
             ### simply displays the "p-value"
             output$p <- renderText({
               if (! vals$run) return (tr("no available p-value yet..."))

--- a/ui.R
+++ b/ui.R
@@ -248,8 +248,9 @@ shinyUI(fluidPage(theme= "bootstrap.css",
                                        conditionalPanel("input.stat == 'ancova1' || input.stat == 'ancova2'", 
                                                         # these stats have three columns
                                                         selectInput("m3", "Column 3", choices=2) # label and choices will be overriden!
-                                       ),
-                                       helpText(tr("Below you see the result of this function applied to the original data:")),
+                                                        ),
+                                       h3(textOutput("stats.help")),
+                                       #helpText(tr("Below you see the result of this function applied to the original data:")),
                                        h3(textOutput("stat")),
                                        # displays a warning in case the statistic is not returning a single number
                                        h4(textOutput("svaluewarning"), style="color:#f30")
@@ -280,6 +281,8 @@ shinyUI(fluidPage(theme= "bootstrap.css",
                                            ##bsTooltip("type", "See the help page for details on the different randomization types."),
                                            checkboxInput("replace", tr("With replacement?")),
                                            selectInput("pside", tr("Alternative:"), choices=Alt),
+                                        #numericInput("fixeds", tr("Change observed statistic to"), value=NULL),
+                                           textInput("fixeds", tr("Change observed statistic to"), value=""),
                                            #bsTooltip("replace", tr("Check this option if you want all the draws to be made independently (that is, with replacement) from the original data")),
                                            #bsTooltip("pside", tr("Use this to select if you want the p-value to be assigned from a two-sided hypothesis (that is, both positive and negative values can be considered extreme), or a one sided test."), "top"),
                                            sliderInput("ntrials", tr("Number of trials:"), min=500,max=10000,value=1000,step=500),


### PR DESCRIPTION
Added a new input box (in Resampling tab) where the user can provide a value for the
statistics of interest. Can be used for example in urn models such as
chi-square statistics: you can resample with replacemente from a null
distribution and then to compare with the observed statistic provided by the user, instead of the statiscis calculated from resampling data. Another potential use is to ask the impact on the significance of increasing/decreasing the observed statistic by a constant.
